### PR TITLE
cepheus: Add PRODUCT_AAPT_PREBUILT_DPI

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -24,6 +24,7 @@ DEVICE_PACKAGE_OVERLAYS += \
 # Screen density
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
+PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 
 # Inherit from sm8150-common
 $(call inherit-product, device/xiaomi/sm8150-common/sm8150.mk)


### PR DESCRIPTION
We add two more density buckets so that if we don't have a best match with PRODUCT_AAPT_PREF_CONFIG, we fall back to the second best.